### PR TITLE
use a for..break because we can't depend on count

### DIFF
--- a/aspell.go
+++ b/aspell.go
@@ -180,26 +180,24 @@ type Dict struct {
 
 // Dicts returns the list of available aspell dictionaries.
 func Dicts() []Dict {
+	var result []Dict
 	config := C.new_aspell_config()
 	dlist := C.get_aspell_dict_info_list(config)
 	C.delete_aspell_config(config)
 
-	count := int(C.aspell_dict_info_list_size(dlist))
-	result := make([]Dict, count)
-
 	dels := C.aspell_dict_info_list_elements(dlist)
-	for i := 0; i < count; i++ {
+	for {
 		entry := C.aspell_dict_info_enumeration_next(dels)
 		if entry == nil {
 			break
 		}
-		result[i] = Dict{
+		result = append(result, Dict{
 			name:   C.GoString(entry.name),
 			code:   C.GoString(entry.code),
 			jargon: C.GoString(entry.jargon),
 			size:   C.GoString(entry.size_str),
 			module: C.GoString(entry.module.name),
-		}
+		})
 	}
 	C.delete_aspell_dict_info_enumeration(dels)
 

--- a/aspell.go
+++ b/aspell.go
@@ -171,11 +171,11 @@ func (s Speller) MainWordList() ([]string, error) {
 
 // Dict represents Aspell dictionary info.
 type Dict struct {
-	name   string
-	code   string
-	jargon string
-	size   string
-	module string
+	Name   string
+	Code   string
+	Jargon string
+	Size   string
+	Module string
 }
 
 // Dicts returns the list of available aspell dictionaries.
@@ -192,11 +192,11 @@ func Dicts() []Dict {
 			break
 		}
 		result = append(result, Dict{
-			name:   C.GoString(entry.name),
-			code:   C.GoString(entry.code),
-			jargon: C.GoString(entry.jargon),
-			size:   C.GoString(entry.size_str),
-			module: C.GoString(entry.module.name),
+			Name:   C.GoString(entry.name),
+			Code:   C.GoString(entry.code),
+			Jargon: C.GoString(entry.jargon),
+			Size:   C.GoString(entry.size_str),
+			Module: C.GoString(entry.module.name),
 		})
 	}
 	C.delete_aspell_dict_info_enumeration(dels)


### PR DESCRIPTION
As commented in http://aspell.net/sf-issue-files/11b76e92/632d/test.c
` aspell_dict_info_list_size(dlist)` will allways return `0` for some
reason.
Execute `aspell_dict_info_enumeration_next(dels)` until it returns nil.

This will resolve #2.